### PR TITLE
Support Text

### DIFF
--- a/tmx_object.go
+++ b/tmx_object.go
@@ -87,6 +87,8 @@ type Object struct {
 	Polygons []*Polygon `xml:"polygon"`
 	// Poly lines
 	PolyLines []*PolyLine `xml:"polyline"`
+	// Text
+	Text Text `xml:"text"`
 }
 
 // Ellipse is used to mark an object as an ellipse.
@@ -127,7 +129,6 @@ func (m *Points) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if item == "" {
 		return nil
 	}
-
 	ps := strings.Split(item, " ")
 
 	points := make(Points, len(ps))
@@ -152,4 +153,19 @@ func (m *Points) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 	*m = (Points)(points)
 	return nil
+}
+
+// Text contains a text and attributes such as bold, color, etc.
+type Text struct {
+	Text       string `xml:",chardata"`
+	Fontfamily string `xml:"fontfamily,attr"`
+	Pixelsize  int    `xml:"pixelsize,attr"`
+	Wrap       bool   `xml:"wrap,attr"`
+	Color      string `xml:"color,attr"`
+	Bold       bool   `xml:"bold,attr"`
+	Italic     bool   `xml:"italic,attr"`
+	Underline  bool   `xml:"underline,attr"`
+	Strikeout  bool   `xml:"strikeout,attr"`
+	Halign     string `xml:"halign,attr"`
+	Valign     string `xml:"valign,attr"`
 }

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -158,15 +158,15 @@ func (m *Points) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 // Text contains a text and attributes such as bold, color, etc.
 type Text struct {
-	Text       string `xml:",chardata"`
-	Fontfamily string `xml:"fontfamily,attr"`
-	Pixelsize  int    `xml:"pixelsize,attr"`
-	Wrap       bool   `xml:"wrap,attr"`
-	Color      string `xml:"color,attr"`
-	Bold       bool   `xml:"bold,attr"`
-	Italic     bool   `xml:"italic,attr"`
-	Underline  bool   `xml:"underline,attr"`
-	Strikeout  bool   `xml:"strikeout,attr"`
-	Halign     string `xml:"halign,attr"`
-	Valign     string `xml:"valign,attr"`
+	Text          string `xml:",chardata"`
+	FontFamily    string `xml:"fontfamily,attr"`
+	Size          int    `xml:"pixelsize,attr"`
+	Wrap          bool   `xml:"wrap,attr"`
+	Color         string `xml:"color,attr"`
+	Bold          bool   `xml:"bold,attr"`
+	Italic        bool   `xml:"italic,attr"`
+	Underline     bool   `xml:"underline,attr"`
+	Strikethrough bool   `xml:"strikeout,attr"`
+	HAlign        string `xml:"halign,attr"`
+	VAlign        string `xml:"valign,attr"`
 }

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -129,6 +129,7 @@ func (m *Points) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if item == "" {
 		return nil
 	}
+
 	ps := strings.Split(item, " ")
 
 	points := make(Points, len(ps))


### PR DESCRIPTION
Would like to add support for Text objects from Tiled.

Example map: https://gist.github.com/kyeett/7beb9b7f50323592780c3c4a97ab98f6

```go
m, err := tiled.LoadFromFile(path)

if err != nil {
	log.Fatal("load map", err)
}
fmt.Printf("%#v", m.ObjectGroups[0].Objects[0].Text)
```

Result (pretty printed):
```go
tiled.Text{
Text:"The test2", 
Fontfamily:"Copperplate", 
Pixelsize:17, 
Wrap:true, 
Color:"#c8010101", 
Bold:true, 
Italic:true, 
Underline:true, 
Strikeout:true, 
Halign:"right", 
Valign:"center"
}
```