### PR TITLE
Add TilesetTile Type value

### DIFF
--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -57,6 +57,8 @@ type Terrain struct {
 type TilesetTile struct {
 	// The local tile ID within its tileset.
 	ID uint32 `xml:"id,attr"`
+	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (since 1.0)
+	Type string `xml:"type,attr"`
 	// Defines the terrain type of each corner of the tile, given as comma-separated indexes in the terrain types
 	// array in the order top-left, top-right, bottom-left, bottom-right.
 	// Leaving out a value means that corner has no terrain. (optional) (since 0.9)


### PR DESCRIPTION
Hi again,

I noticed the Type parameter of TilesetTile was missing. Added it, and a comment from the [documentation](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile).

Here is an examle of my .tmx-file
```xml
<?xml version="1.0" encoding="UTF-8"?>
<map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" infinite="0" nextlayerid="6" nextobjectid="30">
 <tileset firstgid="1" name="all" tilewidth="32" tileheight="32" tilecount="36" columns="6">
  <image source="../spritesheets/tiles.png" trans="6f6d51" width="192" height="192"/>
  <tile id="6" type="alien"/>
  <tile id="7" type="hero"/>
  <tile id="8" type="orcman"/>
  <tile id="9" type="pirate"/>
 </tileset>
...
</map>
```