### PR TITLE
Take into account margin and spacing

### DIFF
--- a/render/renderer.go
+++ b/render/renderer.go
@@ -99,22 +99,30 @@ func (r *Renderer) getTileImage(tile *tiled.LayerTile) (image.Image, error) {
 		tilesetTileCount := tile.Tileset.TileCount
 
 		tilesetColumns := tile.Tileset.Columns
+
+		margin := tile.Tileset.Margin
+
+		spacing := tile.Tileset.Spacing
+
 		if tilesetColumns == 0 {
-			tilesetColumns = tile.Tileset.Image.Width / (tile.Tileset.TileWidth + tile.Tileset.Spacing)
+			tilesetColumns = tile.Tileset.Image.Width / (tile.Tileset.TileWidth + spacing)
 		}
 
 		if tilesetTileCount == 0 {
-			tilesetTileCount = (tile.Tileset.Image.Height / (tile.Tileset.TileHeight + tile.Tileset.Spacing)) * tilesetColumns
+			tilesetTileCount = (tile.Tileset.Image.Height / (tile.Tileset.TileHeight + spacing)) * tilesetColumns
 		}
 
 		for i := tile.Tileset.FirstGID; i < tile.Tileset.FirstGID+uint32(tilesetTileCount); i++ {
 			x := int(i-tile.Tileset.FirstGID) % tilesetColumns
 			y := int(i-tile.Tileset.FirstGID) / tilesetColumns
 
-			rect := image.Rect(x*tile.Tileset.TileWidth,
-				y*tile.Tileset.TileHeight,
-				(x+1)*tile.Tileset.TileWidth,
-				(y+1)*tile.Tileset.TileHeight)
+			xOffset := int(x)*spacing + margin
+			yOffset := int(y)*spacing + margin
+
+			rect := image.Rect(x*tile.Tileset.TileWidth+xOffset,
+				y*tile.Tileset.TileHeight+yOffset,
+				(x+1)*tile.Tileset.TileWidth+xOffset,
+				(y+1)*tile.Tileset.TileHeight+yOffset)
 
 			r.tileCache[i] = imaging.Crop(img, rect)
 			if tile.ID == i-tile.Tileset.FirstGID {


### PR DESCRIPTION
When using a tileset that has margin around the tiles and spacing between the tiles, this isn't taken into account in the main renderer.

When cutting out the rect this adds an xOffset of spacing multiplied by the current column number, and a yOffset of spacing multiplied by the current row number, then adds overall margin to each.

[I have an example repo here which shows the issue](https://github.com/abradley2/ebiten-tiled-example)

Before (on current master)
![Screen Shot 2019-05-18 at 10 17 53 AM](https://user-images.githubusercontent.com/8582764/57971225-2d441e80-7959-11e9-9b71-f4eb2c4c79c3.png)


After (on this branch)
![Screen Shot 2019-05-18 at 10 39 35 AM](https://user-images.githubusercontent.com/8582764/57971232-3fbe5800-7959-11e9-90c3-faafeafca2c5.png)
