### PR TITLE
add Loader for custom and secure file system access

### DIFF
--- a/assets/loader.tmx
+++ b/assets/loader.tmx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="left-down" compressionlevel="-1" width="10" height="10" tilewidth="20" tileheight="20" infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="../README.md"/>
+ <layer id="1" name="Tile Layer 1" width="10" height="10" offsetx="-67" offsety="-2">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,808,809,810,811,
+0,0,0,0,0,0,868,869,870,871,
+0,0,0,0,0,0,928,929,930,931,
+0,0,0,0,0,0,988,989,990,991,
+0,0,0,0,0,0,1048,1049,1050,1051,
+0,0,0,0,0,0,1108,1109,1110,1111,
+0,0,0,0,0,0,1168,1169,1170,1171,
+0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+</map>

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -25,7 +25,6 @@ package tiled
 import (
 	"encoding/xml"
 	"errors"
-	"os"
 	"path/filepath"
 )
 
@@ -47,10 +46,13 @@ var (
 // and image layers use the imagelayer tag. The order in which these layers appear is the order in which the
 // layers are rendered by Tiled
 type Map struct {
-	// The TMX format version, generally 1.0.
-	Version string `xml:"title,attr"`
+	// Loader for loading additional data
+	loader *Loader
 	// Base directory for loading additional data
 	baseDir string
+
+	// The TMX format version, generally 1.0.
+	Version string `xml:"title,attr"`
 	// Map orientation. Tiled supports "orthogonal", "isometric", "staggered" (since 0.9) and "hexagonal" (since 0.11).
 	Orientation string `xml:"orientation,attr"`
 	// The order in which tiles on tile layers are rendered. Valid values are right-down (the default), right-up, left-down and left-up.
@@ -98,7 +100,7 @@ func (m *Map) initTileset(ts *Tileset) (*Tileset, error) {
 		return ts, nil
 	}
 	sourcePath := m.GetFileFullPath(ts.Source)
-	f, err := os.Open(sourcePath)
+	f, err := m.loader.open(sourcePath)
 	if err != nil {
 		return nil, err
 	}
@@ -157,6 +159,7 @@ func (m *Map) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	type Alias Map
 
 	item := Alias{
+		loader:      m.loader,
 		baseDir:     m.baseDir,
 		RenderOrder: "right-down",
 	}

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -8,6 +8,7 @@ import (
 type Tileset struct {
 	// Base directory
 	baseDir string
+
 	// The first global tile ID of this tileset (this global ID maps to the first tile in this tileset).
 	FirstGID uint32 `xml:"firstgid,attr"`
 	// If this tileset is stored in an external TSX (Tile Set XML) file, this attribute refers to that file.


### PR DESCRIPTION
Currently, LoadFromFile and LoadFromReader will attempt to open and read
externally linked tilesets using os.Open. This can be an issue if maps
are from an untrusted source.

To solve this, an http.FileSystem implementation can be set in the Loader
that is used when loading maps and externally linked tilesets.