### PR TITLE
fix Text not setting default Tiled values

### DIFF
--- a/assets/font.tmx
+++ b/assets/font.tmx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.1" orientation="orthogonal" renderorder="left-down" compressionlevel="-1" width="10" height="10" tilewidth="20" tileheight="20" infinite="0" nextlayerid="3" nextobjectid="2">
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="1" x="33" y="73" width="91.4375" height="19">
+   <text wrap="1">Hello World</text>
+  </object>
+ </objectgroup>
+</map>

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -158,3 +158,31 @@ func TestGroup(t *testing.T) {
 	assert.Len(t, c.ObjectGroups, 1)
 	assert.Len(t, c.Groups, 0)
 }
+
+func TestFont(t *testing.T) {
+	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "font.tmx"))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+
+	if assert.Len(t, m.ObjectGroups, 1) {
+		if assert.Len(t, m.ObjectGroups[0].Objects, 1) {
+			if assert.NotNil(t, m.ObjectGroups[0].Objects[0].Text) {
+				text := m.ObjectGroups[0].Objects[0].Text
+
+				assert.Equal(t, "Hello World", text.Text)
+				assert.Equal(t, "sans-serif", text.FontFamily)
+				assert.Equal(t, 16, text.Size)
+				assert.Equal(t, true, text.Wrap)
+				assert.Equal(t, "#000000", text.Color)
+				assert.Equal(t, false, text.Bold)
+				assert.Equal(t, false, text.Italic)
+				assert.Equal(t, false, text.Underline)
+				assert.Equal(t, false, text.Strikethrough)
+				assert.Equal(t, true, text.Kerning)
+				assert.Equal(t, "left", text.HAlign)
+				assert.Equal(t, "top", text.VAlign)
+			}
+		}
+	}
+}

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -92,7 +92,7 @@ type Object struct {
 	// Poly lines
 	PolyLines []*PolyLine `xml:"polyline"`
 	// Text
-	Text Text `xml:"text"`
+	Text *Text `xml:"text"`
 }
 
 // Ellipse is used to mark an object as an ellipse.
@@ -159,15 +159,50 @@ func (m *Points) UnmarshalXMLAttr(attr xml.Attr) error {
 
 // Text contains a text and attributes such as bold, color, etc.
 type Text struct {
-	Text          string `xml:",chardata"`
-	FontFamily    string `xml:"fontfamily,attr"`
-	Size          int    `xml:"pixelsize,attr"`
-	Wrap          bool   `xml:"wrap,attr"`
-	Color         string `xml:"color,attr"`
-	Bold          bool   `xml:"bold,attr"`
-	Italic        bool   `xml:"italic,attr"`
-	Underline     bool   `xml:"underline,attr"`
-	Strikethrough bool   `xml:"strikeout,attr"`
-	HAlign        string `xml:"halign,attr"`
-	VAlign        string `xml:"valign,attr"`
+	// The actual text
+	Text string `xml:",chardata"`
+	// The font family used (default: "sans-serif")
+	FontFamily string `xml:"fontfamily,attr"`
+	// The size of the font in pixels (not using points, because other sizes in the TMX format are also using pixels) (default: 16)
+	Size int `xml:"pixelsize,attr"`
+	// Whether word wrapping is enabled (1) or disabled (0). Defaults to 0.
+	Wrap bool `xml:"wrap,attr"`
+	// Color of the text in #AARRGGBB or #RRGGBB format (default: #000000)
+	Color string `xml:"color,attr"`
+	// Whether the font is bold (1) or not (0). Defaults to 0.
+	Bold bool `xml:"bold,attr"`
+	// Whether the font is italic (1) or not (0). Defaults to 0.
+	Italic bool `xml:"italic,attr"`
+	// Whether a line should be drawn below the text (1) or not (0). Defaults to 0.
+	Underline bool `xml:"underline,attr"`
+	// Whether a line should be drawn through the text (1) or not (0). Defaults to 0.
+	Strikethrough bool `xml:"strikeout,attr"`
+	// Whether kerning should be used while rendering the text (1) or not (0). Default to 1.
+	Kerning bool `xml:"kerning,attr"`
+	// Horizontal alignment of the text within the object (left (default), center, right or justify (since Tiled 1.2.1))
+	HAlign string `xml:"halign,attr"`
+	// Vertical alignment of the text within the object (top (default), center or bottom)
+	VAlign string `xml:"valign,attr"`
+}
+
+// UnmarshalXML decodes a single XML element beginning with the given start element.
+func (t *Text) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type Alias Text
+
+	item := Alias{
+		FontFamily: "sans-serif",
+		Size:       16,
+		Color:      "#000000",
+		Kerning:    true,
+		HAlign:     "left",
+		VAlign:     "top",
+	}
+
+	if err := d.DecodeElement(&item, &start); err != nil {
+		return err
+	}
+
+	*t = (Text)(item)
+
+	return nil
 }


### PR DESCRIPTION
Backwards compatibility note: the Text field of Object is now a pointer to
Text