### PR TITLE
Fix tileset loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lafriks/go-tiled
 
-go 1.13
+go 1.11
 
 require (
 	github.com/disintegration/imaging v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/lafriks/go-tiled
 
+go 1.13
+
 require (
 	github.com/disintegration/imaging v1.6.0
 	github.com/stretchr/testify v1.3.0

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -103,6 +103,7 @@ func TestExternalTilesetImageLoaded(t *testing.T) {
 				if tileset != nil {
 					assert.NotNil(t, tileset.Image)
 					assert.Equal(t, "ProjectUtumno_full.png", tileset.Image.Source)
+					assert.Contains(t, m.Tilesets, tileset)
 				}
 			}
 		}

--- a/tmx_layer.go
+++ b/tmx_layer.go
@@ -83,8 +83,6 @@ type Layer struct {
 	Tiles []*LayerTile
 	// Data
 	data *Data
-	// Tileset if only one is used in layer
-	tileset *Tileset
 	// Set when all entries of the layer are NilTile
 	empty bool
 }
@@ -193,26 +191,15 @@ func (l *Layer) DecodeLayer(m *Map) error {
 	// Data is not needed anymore
 	l.data = nil
 
-	var tileset *Tileset
 	for i := 0; i < len(l.Tiles); i++ {
 		tile := l.Tiles[i]
 		if !tile.Nil {
-			if tileset == nil {
-				tileset = tile.Tileset
-			} else if tileset != tile.Tileset {
-				l.tileset = nil
-				l.empty = false
-				return nil
-			}
+			l.empty = false
+			return nil
 		}
 	}
 
-	l.tileset = tileset
-	l.empty = false
-
-	if tileset == nil {
-		l.empty = true
-	}
+	l.empty = true
 
 	return nil
 }

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -88,35 +88,34 @@ type Map struct {
 	Groups []*Group `xml:"group"`
 }
 
-func (m *Map) initTileset(ts *Tileset) (*Tileset, error) {
+func (m *Map) initTileset(ts *Tileset) error {
 	if ts.SourceLoaded {
-		return ts, nil
+		return nil
 	}
 	if len(ts.Source) == 0 {
 		ts.baseDir = m.baseDir
 		ts.SourceLoaded = true
-		return ts, nil
+		return nil
 	}
 	sourcePath := m.GetFileFullPath(ts.Source)
 	f, err := os.Open(sourcePath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
 
 	d := xml.NewDecoder(f)
 
-	tse := &Tileset{}
-	if err := d.Decode(tse); err != nil {
-		return nil, err
+	if err := d.Decode(ts); err != nil {
+		return err
 	}
 
-	tse.baseDir = filepath.Dir(sourcePath)
-	tse.Source = ts.Source
-	tse.SourceLoaded = true
-	tse.FirstGID = ts.FirstGID
+	ts.baseDir = filepath.Dir(sourcePath)
+	ts.Source = ts.Source
+	ts.SourceLoaded = true
+	ts.FirstGID = ts.FirstGID
 
-	return tse, nil
+	return nil
 }
 
 // TileGIDToTile is used to find tile data by GID
@@ -129,7 +128,8 @@ func (m *Map) TileGIDToTile(gid uint32) (*LayerTile, error) {
 
 	for i := len(m.Tilesets) - 1; i >= 0; i-- {
 		if m.Tilesets[i].FirstGID <= gidBare {
-			ts, err := m.initTileset(m.Tilesets[i])
+			ts := m.Tilesets[i]
+			err := m.initTileset(ts)
 			if err != nil {
 				return nil, err
 			}

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -127,8 +127,7 @@ func (m *Map) TileGIDToTile(gid uint32) (*LayerTile, error) {
 	for i := len(m.Tilesets) - 1; i >= 0; i-- {
 		if m.Tilesets[i].FirstGID <= gidBare {
 			ts := m.Tilesets[i]
-			err := m.initTileset(ts)
-			if err != nil {
+			if err := m.initTileset(ts); err != nil {
 				return nil, err
 			}
 			return &LayerTile{

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -111,9 +111,7 @@ func (m *Map) initTileset(ts *Tileset) error {
 	}
 
 	ts.baseDir = filepath.Dir(sourcePath)
-	ts.Source = ts.Source
 	ts.SourceLoaded = true
-	ts.FirstGID = ts.FirstGID
 
 	return nil
 }


### PR DESCRIPTION
I've noticed that the Tileset in the map structure are never initialized. It looks like a bug in the initTileset function.
Also, the Layer.tileset variable is not used anywhere, is confusing and the code to populate it was really ugly. So I removed it.

VS code keeps suggesting me to add the go 1.13 version to go mod. If you see any inconvenience with it, It can be removed. I think it makes sense that the go.mod registers a minimal valid go version.