### PR TITLE
Implement hexcolor parser

### DIFF
--- a/tiled_test.go
+++ b/tiled_test.go
@@ -179,7 +179,7 @@ func TestFont(t *testing.T) {
 				assert.Equal(t, "sans-serif", text.FontFamily)
 				assert.Equal(t, 16, text.Size)
 				assert.Equal(t, true, text.Wrap)
-				assert.Nil(t, text.Color)
+				assert.Equal(t, &HexColor{}, text.Color)
 				assert.Equal(t, false, text.Bold)
 				assert.Equal(t, false, text.Italic)
 				assert.Equal(t, false, text.Underline)

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -243,13 +243,13 @@ func TestParseHexColor(t *testing.T) {
 		{
 			name: "With alpha",
 			attr: xml.Attr{
-				Value: "#ffffffff",
+				Value: "#aabbccdd",
 			},
 			color: color.RGBA{
-				R: 255,
-				G: 255,
-				B: 255,
-				A: 255,
+				R: 187,
+				G: 204,
+				B: 221,
+				A: 170,
 			},
 		},
 		{
@@ -324,12 +324,12 @@ func TestFormatHexColor(t *testing.T) {
 		{
 			name:  "transparent black",
 			color: NewHexColor(255, 255, 255, 0),
-			hex:   "#ffffff00",
+			hex:   "#00ffffff",
 		},
 		{
 			name:  "50% transparency",
 			color: NewHexColor(255, 255, 255, 128),
-			hex:   "#ffffff80",
+			hex:   "#80ffffff",
 		},
 		{
 			name:  "values encoded with 2 numbers",

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -288,6 +288,18 @@ func TestParseHexColor(t *testing.T) {
 				A: 255,
 			},
 		},
+		{
+			name: "uppercase",
+			attr: xml.Attr{
+				Value: "#ABCDEF",
+			},
+			color: color.RGBA{
+				R: 171,
+				G: 205,
+				B: 239,
+				A: 255,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -298,6 +298,44 @@ func TestParseHexColor(t *testing.T) {
 }
 
 func TestFormatHexColor(t *testing.T) {
-	color := NewHexColor(255, 255, 255, 255)
-	assert.Equal(t, "#ffffffff", color.String())
+	type test struct {
+		name  string
+		color HexColor
+		hex   string
+	}
+	cases := []test{
+		{
+			name:  "alpha ignored at 255",
+			color: NewHexColor(255, 255, 255, 255),
+			hex:   "#ffffff",
+		},
+		{
+			name:  "transparent black",
+			color: NewHexColor(255, 255, 255, 0),
+			hex:   "#ffffff00",
+		},
+		{
+			name:  "50% transparency",
+			color: NewHexColor(255, 255, 255, 128),
+			hex:   "#ffffff80",
+		},
+		{
+			name:  "values encoded with 2 numbers",
+			color: NewHexColor(16, 32, 48, 255),
+			hex:   "#102030",
+		},
+		{
+			name:  "values encoded with 1 numbers",
+			color: NewHexColor(1, 2, 3, 255),
+			hex:   "#010203",
+		},
+		{
+			name:  "zero",
+			color: NewHexColor(0, 0, 0, 0),
+			hex:   "#00000000",
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.hex, c.color.String(), c.name)
+	}
 }

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -1,0 +1,98 @@
+package tiled
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"image/color"
+	"strings"
+)
+
+type HexColor struct {
+	c color.RGBA
+}
+
+func ParseHexColor(s string) (HexColor, error) {
+	c, err := parseHexColor(s)
+	return HexColor{
+		c: c,
+	}, err
+
+}
+
+func NewHexColor(r, g, b, a uint32) HexColor {
+	return HexColor{
+		c: color.RGBA{
+			uint8(r),
+			uint8(g),
+			uint8(b),
+			uint8(a),
+		},
+	}
+}
+
+func (color *HexColor) RGBA() (r, g, b, a uint32) {
+	return color.c.RGBA()
+}
+
+func (color *HexColor) String() string {
+	return fmt.Sprintf("#%x%x%x%x", color.c.R, color.c.G, color.c.B, color.c.A)
+}
+
+func (color *HexColor) UnmarshalXMLAttr(attr xml.Attr) error {
+	c, err := parseHexColor(attr.Value)
+	if err != nil {
+		return err
+	}
+	color.c = c
+	return nil
+}
+
+func (color *HexColor) MarshalXMLAttr(name xml.Name) (attr xml.Attr, err error) {
+	attr.Name = name
+	attr.Value = color.String()
+	return
+}
+
+func parseHexColor(s string) (c color.RGBA, err error) {
+	hexToByte := func(b byte) byte {
+		switch {
+		case b >= '0' && b <= '9':
+			return b - '0'
+		case b >= 'a' && b <= 'f':
+			return b - 'a' + 10
+		case b >= 'A' && b <= 'F':
+			return b - 'A' + 10
+		}
+		err = errors.New("Invalid Format")
+		return 0
+	}
+
+	s = strings.TrimPrefix(s, "#")
+
+	switch len(s) {
+	case 8:
+		c.R = hexToByte(s[0])<<4 + hexToByte(s[1])
+		c.G = hexToByte(s[2])<<4 + hexToByte(s[3])
+		c.B = hexToByte(s[4])<<4 + hexToByte(s[5])
+		c.A = hexToByte(s[6])<<4 + hexToByte(s[7])
+	case 6:
+		c.R = hexToByte(s[0])<<4 + hexToByte(s[1])
+		c.G = hexToByte(s[2])<<4 + hexToByte(s[3])
+		c.B = hexToByte(s[4])<<4 + hexToByte(s[5])
+		c.A = 0xff
+	case 4:
+		c.R = hexToByte(s[0]) * 17
+		c.G = hexToByte(s[1]) * 17
+		c.B = hexToByte(s[2]) * 17
+		c.A = hexToByte(s[3]) * 17
+	case 3:
+		c.R = hexToByte(s[0]) * 17
+		c.G = hexToByte(s[1]) * 17
+		c.B = hexToByte(s[2]) * 17
+		c.A = 0xff
+	default:
+		err = errors.New("Invalid Format")
+	}
+	return
+}

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -15,9 +15,9 @@ type HexColor struct {
 func ParseHexColor(s string) (HexColor, error) {
 	c, err := parseHexColor(s)
 	if err != nil {
-		return nil, err
+		return HexColor{}, err
 	}
-	return HexColor{ c: c }, nil
+	return HexColor{c: c}, nil
 }
 
 func NewHexColor(r, g, b, a uint32) HexColor {

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+// HexColor handles the conversion between hex color strings
+// to color.RGBA structure.
 type HexColor struct {
 	c color.RGBA
 }
@@ -58,6 +60,7 @@ func (color *HexColor) String() string {
 	return string(dst)
 }
 
+// UnmarshalXMLAttr implements xml.UnmarshalerAttr
 func (color *HexColor) UnmarshalXMLAttr(attr xml.Attr) error {
 	c, err := parseHexColor(attr.Value)
 	if err != nil {
@@ -67,6 +70,7 @@ func (color *HexColor) UnmarshalXMLAttr(attr xml.Attr) error {
 	return nil
 }
 
+// MarshalXMLAttr implements xml.MarshalerAttr
 func (color *HexColor) MarshalXMLAttr(name xml.Name) (attr xml.Attr, err error) {
 	attr.Name = name
 	attr.Value = color.String()

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 )
 
-// HexColor handles the conversion between hex color strings
-// to color.RGBA structure.
+// HexColor handles the conversion between hex color strings in form #AARRGGBB
+// to color.RGBA structure. Be aware that this doesn't match CSS hex color because
+// the alpha channel appears first.
 type HexColor struct {
 	c color.RGBA
 }

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -74,7 +74,9 @@ func (color *HexColor) UnmarshalXMLAttr(attr xml.Attr) error {
 // MarshalXMLAttr implements xml.MarshalerAttr
 func (color *HexColor) MarshalXMLAttr(name xml.Name) (attr xml.Attr, err error) {
 	attr.Name = name
-	attr.Value = color.String()
+	if color != nil {
+		attr.Value = color.String()
+	}
 	return
 }
 

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -12,6 +12,10 @@ type HexColor struct {
 	c color.RGBA
 }
 
+// ParseHexColor converts hex color strings into HexColor structures
+// This function can handle colors with and withouth optional alpha channel
+// The leading '#' character is not required for backwards compatibility with Transparency Tiled filed
+// https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#image
 func ParseHexColor(s string) (HexColor, error) {
 	c, err := parseHexColor(s)
 	if err != nil {
@@ -20,6 +24,7 @@ func ParseHexColor(s string) (HexColor, error) {
 	return HexColor{c: c}, nil
 }
 
+// NewHexColor is a shorthand to build a HexColor
 func NewHexColor(r, g, b, a uint32) HexColor {
 	return HexColor{
 		c: color.RGBA{
@@ -31,6 +36,7 @@ func NewHexColor(r, g, b, a uint32) HexColor {
 	}
 }
 
+// RGBA implements color.Color interface
 func (color *HexColor) RGBA() (r, g, b, a uint32) {
 	return color.c.RGBA()
 }

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -45,13 +45,13 @@ func (color *HexColor) RGBA() (r, g, b, a uint32) {
 
 func (color *HexColor) String() string {
 	src := []byte{
+		color.c.A,
 		color.c.R,
 		color.c.G,
 		color.c.B,
-		color.c.A,
 	}
 	if color.c.A == 255 {
-		src = src[:len(src)-1]
+		src = src[1:]
 	}
 
 	dst := make([]byte, hex.EncodedLen(len(src))+1)
@@ -95,25 +95,25 @@ func parseHexColor(s string) (c color.RGBA, err error) {
 
 	switch len(s) {
 	case 8:
-		c.R = hexToByte(s[0])<<4 + hexToByte(s[1])
-		c.G = hexToByte(s[2])<<4 + hexToByte(s[3])
-		c.B = hexToByte(s[4])<<4 + hexToByte(s[5])
-		c.A = hexToByte(s[6])<<4 + hexToByte(s[7])
+		c.A = hexToByte(s[0])<<4 + hexToByte(s[1])
+		c.R = hexToByte(s[2])<<4 + hexToByte(s[3])
+		c.G = hexToByte(s[4])<<4 + hexToByte(s[5])
+		c.B = hexToByte(s[6])<<4 + hexToByte(s[7])
 	case 6:
+		c.A = 0xff
 		c.R = hexToByte(s[0])<<4 + hexToByte(s[1])
 		c.G = hexToByte(s[2])<<4 + hexToByte(s[3])
 		c.B = hexToByte(s[4])<<4 + hexToByte(s[5])
-		c.A = 0xff
 	case 4:
-		c.R = hexToByte(s[0]) * 17
-		c.G = hexToByte(s[1]) * 17
-		c.B = hexToByte(s[2]) * 17
-		c.A = hexToByte(s[3]) * 17
+		c.A = hexToByte(s[0]) * 17
+		c.R = hexToByte(s[1]) * 17
+		c.G = hexToByte(s[2]) * 17
+		c.B = hexToByte(s[3]) * 17
 	case 3:
+		c.A = 0xff
 		c.R = hexToByte(s[0]) * 17
 		c.G = hexToByte(s[1]) * 17
 		c.B = hexToByte(s[2]) * 17
-		c.A = 0xff
 	default:
 		err = errors.New("Invalid Format")
 	}

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -14,10 +14,10 @@ type HexColor struct {
 
 func ParseHexColor(s string) (HexColor, error) {
 	c, err := parseHexColor(s)
-	return HexColor{
-		c: c,
-	}, err
-
+	if err != nil {
+		return nil, err
+	}
+	return HexColor{ c: c }, nil
 }
 
 func NewHexColor(r, g, b, a uint32) HexColor {

--- a/tmx_hexcolor.go
+++ b/tmx_hexcolor.go
@@ -1,9 +1,9 @@
 package tiled
 
 import (
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"image/color"
 	"strings"
 )
@@ -36,7 +36,20 @@ func (color *HexColor) RGBA() (r, g, b, a uint32) {
 }
 
 func (color *HexColor) String() string {
-	return fmt.Sprintf("#%x%x%x%x", color.c.R, color.c.G, color.c.B, color.c.A)
+	src := []byte{
+		color.c.R,
+		color.c.G,
+		color.c.B,
+		color.c.A,
+	}
+	if color.c.A == 255 {
+		src = src[:len(src)-1]
+	}
+
+	dst := make([]byte, hex.EncodedLen(len(src))+1)
+	hex.Encode(dst[1:], src)
+	dst[0] = '#'
+	return string(dst)
 }
 
 func (color *HexColor) UnmarshalXMLAttr(attr xml.Attr) error {

--- a/tmx_image.go
+++ b/tmx_image.go
@@ -78,7 +78,7 @@ type Image struct {
 	Source string `xml:"source,attr"`
 	// Defines a specific color that is treated as transparent (example value: "#FF00FF" for magenta).
 	// Up until Tiled 0.12, this value is written out without a # but this is planned to change.
-	Trans string `xml:"trans,attr"`
+	Trans *HexColor `xml:"trans,attr"`
 	// The image width in pixels (optional, used for tile index correction when the image changes)
 	Width int `xml:"width,attr"`
 	// The image height in pixels (optional)

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -73,7 +73,7 @@ type Map struct {
 	// For staggered and hexagonal maps, determines whether the "even" or "odd" indexes along the staggered axis are shifted. (since 0.11)
 	StaggerIndex int `xml:"staggerindex,attr"`
 	// The background color of the map. (since 0.9, optional, may include alpha value since 0.15 in the form #AARRGGBB)
-	BackgroundColor string `xml:"backgroundcolor,attr"`
+	BackgroundColor *HexColor `xml:"backgroundcolor,attr"`
 	// Stores the next available ID for new objects. This number is stored to prevent reuse of the same ID after objects have been removed. (since 0.11)
 	NextObjectID uint32 `xml:"nextobjectid,attr"`
 	// Custom properties

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -195,6 +195,7 @@ func (t *Text) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		Kerning:    true,
 		HAlign:     "left",
 		VAlign:     "top",
+		Color:      &HexColor{},
 	}
 
 	if err := d.DecodeElement(&item, &start); err != nil {

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -43,7 +43,7 @@ type ObjectGroup struct {
 	// The name of the object group.
 	Name string `xml:"name,attr"`
 	// The color used to display the objects in this group.
-	Color string `xml:"color,attr"`
+	Color *HexColor `xml:"color,attr"`
 	// The opacity of the layer as a value from 0 to 1. Defaults to 1.
 	Opacity float32 `xml:"opacity,attr"`
 	// Whether the layer is shown (1) or hidden (0). Defaults to 1.
@@ -167,8 +167,8 @@ type Text struct {
 	Size int `xml:"pixelsize,attr"`
 	// Whether word wrapping is enabled (1) or disabled (0). Defaults to 0.
 	Wrap bool `xml:"wrap,attr"`
-	// Color of the text in #AARRGGBB or #RRGGBB format (default: #000000)
-	Color string `xml:"color,attr"`
+	// Color of the text, Default nil
+	Color *HexColor `xml:"color,attr"`
 	// Whether the font is bold (1) or not (0). Defaults to 0.
 	Bold bool `xml:"bold,attr"`
 	// Whether the font is italic (1) or not (0). Defaults to 0.
@@ -192,7 +192,6 @@ func (t *Text) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	item := Alias{
 		FontFamily: "sans-serif",
 		Size:       16,
-		Color:      "#000000",
 		Kerning:    true,
 		HAlign:     "left",
 		VAlign:     "top",

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -167,7 +167,7 @@ type Text struct {
 	Size int `xml:"pixelsize,attr"`
 	// Whether word wrapping is enabled (1) or disabled (0). Defaults to 0.
 	Wrap bool `xml:"wrap,attr"`
-	// Color of the text (default: #000000)
+	// Color of the text in #AARRGGBB or #RRGGBB format (default: #000000)
 	Color *HexColor `xml:"color,attr"`
 	// Whether the font is bold (1) or not (0). Defaults to 0.
 	Bold bool `xml:"bold,attr"`

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -167,7 +167,7 @@ type Text struct {
 	Size int `xml:"pixelsize,attr"`
 	// Whether word wrapping is enabled (1) or disabled (0). Defaults to 0.
 	Wrap bool `xml:"wrap,attr"`
-	// Color of the text, Default (default: #000000)
+	// Color of the text (default: #000000)
 	Color *HexColor `xml:"color,attr"`
 	// Whether the font is bold (1) or not (0). Defaults to 0.
 	Bold bool `xml:"bold,attr"`

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -167,7 +167,7 @@ type Text struct {
 	Size int `xml:"pixelsize,attr"`
 	// Whether word wrapping is enabled (1) or disabled (0). Defaults to 0.
 	Wrap bool `xml:"wrap,attr"`
-	// Color of the text, Default nil
+	// Color of the text, Default (default: #000000)
 	Color *HexColor `xml:"color,attr"`
 	// Whether the font is bold (1) or not (0). Defaults to 0.
 	Bold bool `xml:"bold,attr"`


### PR DESCRIPTION
I've started to play again with this parser and I've noticed that having the colors as strings is annoying. For this reason, I've created the HexColor type to hold the values as color.RGBA and to implement the `color.Color` interface.

This is cool because most of the game engines for go already know how to read from the `color.Color` interface.

Another advantage is that we can tell if the color was undefined or it was black.