### PR TITLE
parse int and float properties

### DIFF
--- a/tmx_property.go
+++ b/tmx_property.go
@@ -22,6 +22,8 @@ SOFTWARE.
 
 package tiled
 
+import "strconv"
+
 // Properties wraps any number of custom properties
 type Properties []*Property
 
@@ -67,9 +69,37 @@ func (p Properties) GetString(name string) string {
 // GetBool finds first bool property by specified name
 func (p Properties) GetBool(name string) bool {
 	for _, property := range p {
-		if property.Name == name && property.Type == "Boolean" {
+		if property.Name == name && property.Type == "boolean" {
 			return property.Value == "true"
 		}
 	}
 	return p.GetString(name) == "true"
+}
+
+// GetInt finds first int property by specified name
+func (p Properties) GetInt(name string) int {
+	for _, property := range p {
+		if property.Name == name && property.Type == "int" {
+			v, err := strconv.Atoi(property.Value)
+			if err != nil {
+				continue
+			}
+			return v
+		}
+	}
+	return 0
+}
+
+// GetFloat finds first float property by specified name
+func (p Properties) GetFloat(name string) float64 {
+	for _, property := range p {
+		if property.Name == name && property.Type == "float" {
+			v, err := strconv.ParseFloat(property.Value, 64)
+			if err != nil {
+				continue
+			}
+			return v
+		}
+	}
+	return 0
 }

--- a/tmx_property_test.go
+++ b/tmx_property_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2017 Lauris Bukšis-Haberkorns <lauris@nix.lv>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tiled
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProperty(t *testing.T) {
+
+	props := Properties{
+		{
+			Name:  "string-name",
+			Type:  "string",
+			Value: "string-value",
+		},
+		{
+			Name:  "int-name",
+			Type:  "int",
+			Value: "123",
+		},
+		{
+			Name:  "float-name",
+			Type:  "float",
+			Value: "1.23",
+		},
+		{
+			Name:  "bool-name",
+			Type:  "boolean",
+			Value: "true",
+		},
+	}
+
+	assert.Equal(t, "string-value", props.GetString("string-name"))
+	assert.Equal(t, 123, props.GetInt("int-name"))
+	assert.Equal(t, 1.23, props.GetFloat("float-name"))
+	assert.Equal(t, true, props.GetBool("bool-name"))
+}


### PR DESCRIPTION
I noticed that not all the property types are implemented, In fact, only boolean is implemented.

This merge request fix a bug in GetBool and implements GetInt and GetFloat.

PD: I will add tests, give me some time :)