### PR TITLE
Move rectangle calculation methods from Rendering to Tileset

### DIFF
--- a/render/renderer.go
+++ b/render/renderer.go
@@ -114,36 +114,10 @@ func (r *Renderer) getTileImage(tile *tiled.LayerTile) (image.Image, error) {
 			return nil, err
 		}
 
-		tilesetTileCount := tile.Tileset.TileCount
-
-		tilesetColumns := tile.Tileset.Columns
-
-		margin := tile.Tileset.Margin
-
-		spacing := tile.Tileset.Spacing
-
-		if tilesetColumns == 0 {
-			tilesetColumns = tile.Tileset.Image.Width / (tile.Tileset.TileWidth + spacing)
-		}
-
-		if tilesetTileCount == 0 {
-			tilesetTileCount = (tile.Tileset.Image.Height / (tile.Tileset.TileHeight + spacing)) * tilesetColumns
-		}
-
-		for i := tile.Tileset.FirstGID; i < tile.Tileset.FirstGID+uint32(tilesetTileCount); i++ {
-			x := int(i-tile.Tileset.FirstGID) % tilesetColumns
-			y := int(i-tile.Tileset.FirstGID) / tilesetColumns
-
-			xOffset := int(x)*spacing + margin
-			yOffset := int(y)*spacing + margin
-
-			rect := image.Rect(x*tile.Tileset.TileWidth+xOffset,
-				y*tile.Tileset.TileHeight+yOffset,
-				(x+1)*tile.Tileset.TileWidth+xOffset,
-				(y+1)*tile.Tileset.TileHeight+yOffset)
-
-			r.tileCache[i] = imaging.Crop(img, rect)
-			if tile.ID == i-tile.Tileset.FirstGID {
+		for i := uint32(0); i < uint32(tile.Tileset.TileCount); i++ {
+			rect := tile.Tileset.GetTileRect(i)
+			r.tileCache[i+tile.Tileset.FirstGID] = imaging.Crop(img, rect)
+			if tile.ID == i {
 				timg = r.tileCache[i]
 			}
 		}

--- a/tmx_layer.go
+++ b/tmx_layer.go
@@ -25,6 +25,7 @@ package tiled
 import (
 	"encoding/xml"
 	"errors"
+	"image"
 )
 
 // NilLayerTile is reusable layer tile that is nil
@@ -228,4 +229,16 @@ func (l *Layer) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	l.data = item.Data
 
 	return nil
+}
+
+// GetTilePosition returns the x,y position of the tileID on the current layer
+func (l *Layer) GetTilePosition(tileID int) (int, int) {
+	x := tileID % l._map.Width
+	y := tileID / l._map.Width
+	return l.OffsetX + x*l._map.TileHeight, l.OffsetY + y*l._map.TileWidth
+}
+
+// GetTileRect returns the rectangle that contains the Tile in the original Tileset.Image
+func (t *LayerTile) GetTileRect() image.Rectangle {
+	return t.Tileset.GetTileRect(t.ID)
 }

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -103,26 +103,26 @@ type AnimationFrame struct {
 }
 
 // GetTileRect returns a rectangle that contains the tile in the tileset.Image
-func (tileset *Tileset) GetTileRect(tileID uint32) image.Rectangle {
-	tilesetTileCount := tileset.TileCount
-	tilesetColumns := tileset.Columns
+func (ts *Tileset) GetTileRect(tileID uint32) image.Rectangle {
+	tilesetTileCount := ts.TileCount
+	tilesetColumns := ts.Columns
 
 	if tilesetColumns == 0 {
-		tilesetColumns = tileset.Image.Width / (tileset.TileWidth + tileset.Spacing)
+		tilesetColumns = ts.Image.Width / (ts.TileWidth + ts.Spacing)
 	}
 
 	if tilesetTileCount == 0 {
-		tilesetTileCount = (tileset.Image.Height / (tileset.TileHeight + tileset.Spacing)) * tilesetColumns
+		tilesetTileCount = (ts.Image.Height / (ts.TileHeight + ts.Spacing)) * tilesetColumns
 	}
 
 	x := int(tileID) % tilesetColumns
 	y := int(tileID) / tilesetColumns
 
-	xOffset := int(x)*tileset.Spacing + tileset.Margin
-	yOffset := int(y)*tileset.Spacing + tileset.Margin
+	xOffset := int(x)*ts.Spacing + ts.Margin
+	yOffset := int(y)*ts.Spacing + ts.Margin
 
-	return image.Rect(x*tileset.TileWidth+xOffset,
-		y*tileset.TileHeight+yOffset,
-		(x+1)*tileset.TileWidth+xOffset,
-		(y+1)*tileset.TileHeight+yOffset)
+	return image.Rect(x*ts.TileWidth+xOffset,
+		y*ts.TileHeight+yOffset,
+		(x+1)*ts.TileWidth+xOffset,
+		(y+1)*ts.TileHeight+yOffset)
 }

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -1,6 +1,7 @@
 package tiled
 
 import (
+	"image"
 	"path/filepath"
 )
 
@@ -99,4 +100,29 @@ type AnimationFrame struct {
 	TileID uint32 `xml:"tileid,attr"`
 	// How long (in milliseconds) this frame should be displayed before advancing to the next frame.
 	Duration uint32 `xml:"duration,attr"`
+}
+
+// GetTileRect returns a rectangle that contains the tile in the tileset.Image
+func (tileset *Tileset) GetTileRect(tileID uint32) image.Rectangle {
+	tilesetTileCount := tileset.TileCount
+	tilesetColumns := tileset.Columns
+
+	if tilesetColumns == 0 {
+		tilesetColumns = tileset.Image.Width / (tileset.TileWidth + tileset.Spacing)
+	}
+
+	if tilesetTileCount == 0 {
+		tilesetTileCount = (tileset.Image.Height / (tileset.TileHeight + tileset.Spacing)) * tilesetColumns
+	}
+
+	x := int(tileID) % tilesetColumns
+	y := int(tileID) / tilesetColumns
+
+	xOffset := int(x)*tileset.Spacing + tileset.Margin
+	yOffset := int(y)*tileset.Spacing + tileset.Margin
+
+	return image.Rect(x*tileset.TileWidth+xOffset,
+		y*tileset.TileHeight+yOffset,
+		(x+1)*tileset.TileWidth+xOffset,
+		(y+1)*tileset.TileHeight+yOffset)
 }

--- a/tmx_tileset_test.go
+++ b/tmx_tileset_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright (c) 2017 Lauris Bukšis-Haberkorns <lauris@nix.lv>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package tiled
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTileRect(t *testing.T) {
+
+	type Case struct {
+		id   uint32
+		rect image.Rectangle
+	}
+
+	type test struct {
+		name  string
+		ts    Tileset
+		cases []Case
+	}
+
+	tests := []test{
+		{
+			name: "Columns defined",
+			ts: Tileset{
+				TileCount:  4,
+				Columns:    2,
+				TileWidth:  10,
+				TileHeight: 10,
+			},
+			cases: []Case{
+				{
+					id:   0,
+					rect: image.Rect(0, 0, 10, 10),
+				},
+				{
+					id:   1,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(10, 0)),
+				},
+				{
+					id:   2,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(0, 10)),
+				},
+				{
+					id:   3,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(10, 10)),
+				},
+			},
+		},
+		{
+			name: "With Spacing",
+			ts: Tileset{
+				TileCount:  4,
+				Columns:    2,
+				TileWidth:  10,
+				TileHeight: 10,
+				Spacing:    5,
+			},
+			cases: []Case{
+				{
+					id:   0,
+					rect: image.Rect(0, 0, 10, 10),
+				},
+				{
+					id:   1,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(15, 0)),
+				},
+				{
+					id:   2,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(0, 15)),
+				},
+				{
+					id:   3,
+					rect: image.Rect(0, 0, 10, 10).Add(image.Pt(15, 15)),
+				},
+			},
+		},
+		{
+			name: "With Margin",
+			ts: Tileset{
+				TileCount:  4,
+				Columns:    2,
+				TileWidth:  10,
+				TileHeight: 10,
+				Margin:     5,
+			},
+			cases: []Case{
+				{
+					id:   0,
+					rect: image.Rect(5, 5, 15, 15),
+				},
+				{
+					id:   1,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(10, 0)),
+				},
+				{
+					id:   2,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(0, 10)),
+				},
+				{
+					id:   3,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(10, 10)),
+				},
+			},
+		},
+		{
+			name: "With Margin And Spacing",
+			ts: Tileset{
+				TileCount:  4,
+				Columns:    2,
+				TileWidth:  10,
+				TileHeight: 10,
+				Margin:     5,
+				Spacing:    5,
+			},
+			cases: []Case{
+				{
+					id:   0,
+					rect: image.Rect(5, 5, 15, 15),
+				},
+				{
+					id:   1,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(15, 0)),
+				},
+				{
+					id:   2,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(0, 15)),
+				},
+				{
+					id:   3,
+					rect: image.Rect(5, 5, 15, 15).Add(image.Pt(15, 15)),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, c := range test.cases {
+				rect := test.ts.GetTileRect(c.id)
+				assert.Equal(t, c.rect, rect)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
I've found myself doing a copy-paste from the renderer code, so I think it is worth to include the logic to calculate the rectangles to crop the tileset into the tiled.Tileset.