### PR TITLE
Decoding Group Layers

### DIFF
--- a/assets/groups.tmx
+++ b/assets/groups.tmx
@@ -10,7 +10,7 @@
    <layer id="3" name="Tile Layer 2" width="20" height="20">
     <data encoding="base64" compression="zlib">
    eJxjYBgFo2AUjIJRMApIBwAGQAAB
-  </data>
+    </data>
    </layer>
    <group id="8" name="C">
     <objectgroup id="7" name="Object Layer 1"/>

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -162,10 +162,10 @@ func TestGroup(t *testing.T) {
 	assert.Len(t, b.Layers, 1)
 	assert.Len(t, b.Groups, 1)
 
-	b_l := b.Layers[0]
-	assert.Equal(t, uint32(3), b_l.ID)
-	assert.Equal(t, b_l.Name, "Tile Layer 2")
-	assert.Len(t, b_l.Tiles, 400)
+	bL := b.Layers[0]
+	assert.Equal(t, uint32(3), bL.ID)
+	assert.Equal(t, bL.Name, "Tile Layer 2")
+	assert.Len(t, bL.Tiles, 400)
 
 	c := b.Groups[0]
 	assert.Equal(t, uint32(8), c.ID)

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -162,6 +162,11 @@ func TestGroup(t *testing.T) {
 	assert.Len(t, b.Layers, 1)
 	assert.Len(t, b.Groups, 1)
 
+	b_l := b.Layers[0]
+	assert.Equal(t, uint32(3), b_l.ID)
+	assert.Equal(t, b_l.Name, "Tile Layer 2")
+	assert.Len(t, b_l.Tiles, 400)
+
 	c := b.Groups[0]
 	assert.Equal(t, uint32(8), c.ID)
 	assert.Equal(t, "C", c.Name)

--- a/tmx_group.go
+++ b/tmx_group.go
@@ -71,3 +71,21 @@ func (g *Group) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 	return nil
 }
+
+func (g *Group) DecodeGroup(m *Map) error {
+	for i := 0; i < len(g.Groups); i++ {
+		g := g.Groups[i]
+		if err := g.DecodeGroup(m); err != nil {
+			return err
+		}
+	}
+
+	for i := 0; i < len(g.Layers); i++ {
+		l := g.Layers[i]
+		if err := l.DecodeLayer(m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tmx_group.go
+++ b/tmx_group.go
@@ -72,6 +72,8 @@ func (g *Group) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
+// DecodeGroup decodes Group data. This includes all subgroups and the Layer 
+// data for each.
 func (g *Group) DecodeGroup(m *Map) error {
 	for i := 0; i < len(g.Groups); i++ {
 		g := g.Groups[i]

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -167,6 +167,14 @@ func (m *Map) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 
+	// Decode Groups data
+	for i := 0; i < len(item.Groups); i++ {
+		g := item.Groups[i]
+		if err := g.DecodeGroup((*Map)(&item)); err != nil {
+			return err
+		}
+	}
+
 	// Decode layers data
 	for i := 0; i < len(item.Layers); i++ {
 		l := item.Layers[i]

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -83,7 +83,7 @@ type TilesetTile struct {
 	// Leaving out a value means that corner has no terrain. (optional) (since 0.9)
 	Terrain string `xml:"terrain,attr"`
 	// A percentage indicating the probability that this tile is chosen when it competes with others while editing with the terrain tool. (optional) (since 0.9)
-	Probability int `xml:"probability,attr"`
+	Probability float32 `xml:"probability,attr"`
 	// Custom properties
 	Properties Properties `xml:"properties>property"`
 	// Embedded image


### PR DESCRIPTION
Group support was added in #14. However, if a group (or subgroup) contains a Layer, the layer's tile data is not loaded because DecodeLayer is never called on those layers. This corrects that and adds a minimal test to ensure that the tile data is loaded.

Additionally the Tileset type's Probability member has been changed to a float32 to match the type of data used by Tiled. I was receiving a conversion error when the type was an int. The value is clearly a float in the Tiled format.