### PR TITLE
Fix Tilesets not being loaded if only referenced by tile objects.

### DIFF
--- a/assets/test_tileobject.tmx
+++ b/assets/test_tileobject.tmx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.3" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="4" nextobjectid="2">
+ <tileset firstgid="1" source="tilesets/test2.tsx"/>
+ <objectgroup id="3" name="Off-tile objects">
+  <object id="1" gid="8" x="146.667" y="108" width="32" height="32">
+  </object>
+ </objectgroup>
+</map>

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -183,6 +183,11 @@ func (m *Map) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		}
 	}
 
+	// Decode object groups.
+	for _, g := range item.ObjectGroups {
+		g.DecodeObjectGroup((*Map)(&item))
+	}
+
 	*m = (Map)(item)
 	return nil
 }

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -60,6 +60,18 @@ type ObjectGroup struct {
 	Objects []*Object `xml:"object"`
 }
 
+// DecodeObjectGroup decodes object group data
+func (g *ObjectGroup) DecodeObjectGroup(m *Map) {
+	for _, object := range g.Objects {
+		if object.GID > 0 {
+			// Initialize all tilesets that are referenced by tile objects. Otherwise,
+			// if a tileset is used by an object tile but not used by any layer it
+			// won't be loaded.
+			m.TileGIDToTile(object.GID)
+		}
+	}
+}
+
 // Object is used to add custom information to your tile map, such as spawn points, warps, exits, etc.
 type Object struct {
 	// Unique ID of the object. Each object that is placed on a map gets a unique id. Even if an object was deleted, no object gets the same ID.

--- a/tmx_object_test.go
+++ b/tmx_object_test.go
@@ -1,0 +1,27 @@
+/*
+   Copyright 2021 Google LLC.
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package tiled_test
+
+import (
+	"testing"
+
+	"github.com/lafriks/go-tiled"
+)
+
+func TestLoadTilesetReferencedOnlyByObjectGroup(t *testing.T) {
+	const mapPath = "assets/test_tileobject.tmx"
+
+	m, err := tiled.LoadFromFile(mapPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, ts := range m.Tilesets {
+		if !ts.SourceLoaded {
+			t.Errorf("Tileset %q was not loaded by map %q", ts.Source, mapPath)
+		}
+	}
+}


### PR DESCRIPTION
TMX maps contain object groups that can be of several types, such as,
rectangles, points, etc. One of these types is a tile object, which
are objects that have a tile GID field. If this field is set then the
tile refers to a tile within a tileset.

If the tileset is used by a tile object but otherwise not used in any
of the layers, then the library will not load this tileset.

This patch extends the decoding logic to include decoding object
groups also. To decode an object group, all objects contained in the
object group are traversed and in case the object has a GID set, then
the corresponding tileset is initialized by calling TileGIDToTile,
which is also the stragegy used by layer decoding.

Fixes #47