### PR TITLE
Add support for using embedded file systems.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ trigger:
 
 steps:
   - name: lint
-    image: golang:1.13
+    image: golang:1.16
     pull: always
     commands:
       - go vet -all .
@@ -23,7 +23,7 @@ steps:
       - revive -config .revive.toml -exclude=./vendor/... ./...
 
   - name: test
-    image: golang:1.13
+    image: golang:1.16
     pull: always
     commands:
       - go test -v .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lafriks/go-tiled
 
-go 1.13
+go 1.16
 
 require (
 	github.com/disintegration/imaging v1.6.2

--- a/tiled.go
+++ b/tiled.go
@@ -25,7 +25,7 @@ package tiled
 import (
 	"encoding/xml"
 	"io"
-	"net/http"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -47,12 +47,12 @@ type Loader struct {
 	// resources it may reference.
 	//
 	// A nil FileSystem uses the local file system.
-	FileSystem http.FileSystem
+	FileSystem fs.FS
 }
 
 // open opens the given file using the Loader's FileSystem, or uses os.Open
 // if l or l.FileSystem is nil.
-func (l *Loader) open(name string) (http.File, error) {
+func (l *Loader) open(name string) (fs.File, error) {
 	if l == nil || l.FileSystem == nil {
 		return os.Open(name)
 	}
@@ -83,10 +83,6 @@ func (l *Loader) LoadFromFile(fileName string) (*Map, error) {
 	}
 	defer f.Close()
 
-	dir, err := filepath.Abs(filepath.Dir(fileName))
-	if err != nil {
-		return nil, err
-	}
-
+	dir := filepath.Dir(fileName)
 	return l.LoadFromReader(dir, f)
 }


### PR DESCRIPTION
Fixes #57. Switches from using `http` to `fs` and adds a unit test.