### PR TITLE
Add options for Loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const mapPath = "maps/map.tmx" // Path to your Tiled Map.
 
 func main() {
     // Parse .tmx file.
-    gameMap, err := tiled.LoadFromFile(mapPath)
+    gameMap, err := tiled.LoadFile(mapPath)
     if err != nil {
         fmt.Printf("error parsing map: %s", err.Error()
         os.Exit(2)

--- a/example/tmx2img/main.go
+++ b/example/tmx2img/main.go
@@ -18,7 +18,7 @@ func main() {
 		img = "map.png"
 	}
 
-	m, err := tiled.LoadFromFile(filename)
+	m, err := tiled.LoadFile(filename)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/tiled.go
+++ b/tiled.go
@@ -32,13 +32,15 @@ import (
 
 // LoadFromReader function loads tiled map in TMX format from io.Reader
 // baseDir is used for loading additional tile data, current directory is used if empty
-func LoadFromReader(baseDir string, r io.Reader) (*Map, error) {
-	return (*Loader)(nil).LoadFromReader(baseDir, r)
+func LoadFromReader(baseDir string, r io.Reader, options ...loaderOption) (*Map, error) {
+	l := newLoader(options...)
+	return l.LoadFromReader(baseDir, r)
 }
 
 // LoadFromFile function loads tiled map in TMX format from file
-func LoadFromFile(fileName string) (*Map, error) {
-	return (*Loader)(nil).LoadFromFile(fileName)
+func LoadFromFile(fileName string, options ...loaderOption) (*Map, error) {
+	l := newLoader(options...)
+	return l.LoadFromFile(fileName)
 }
 
 // Loader provides configuration on how TMX maps and resources are loaded.
@@ -50,6 +52,16 @@ type Loader struct {
 	FileSystem fs.FS
 }
 
+type loaderOption func(*Loader)
+
+func newLoader(options ...loaderOption) *Loader {
+	l := &Loader{}
+	for _, opt := range options {
+		opt(l)
+	}
+	return l
+}
+
 // open opens the given file using the Loader's FileSystem, or uses os.Open
 // if l or l.FileSystem is nil.
 func (l *Loader) open(name string) (fs.File, error) {
@@ -57,6 +69,13 @@ func (l *Loader) open(name string) (fs.File, error) {
 		return os.Open(name)
 	}
 	return l.FileSystem.Open(name)
+}
+
+// WithFileSystem returns an option to load level from a passed filesystem
+func WithFileSystem(fileSystem fs.FS) loaderOption {
+	return func(l *Loader) {
+		l.FileSystem = fileSystem
+	}
 }
 
 // LoadFromReader function loads tiled map in TMX format from io.Reader

--- a/tiled.go
+++ b/tiled.go
@@ -32,13 +32,13 @@ import (
 
 // LoadFromReader function loads tiled map in TMX format from io.Reader
 // baseDir is used for loading additional tile data, current directory is used if empty
-func LoadFromReader(baseDir string, r io.Reader, options ...loaderOption) (*Map, error) {
+func LoadFromReader(baseDir string, r io.Reader, options ...LoaderOption) (*Map, error) {
 	l := newLoader(options...)
 	return l.LoadFromReader(baseDir, r)
 }
 
 // LoadFromFile function loads tiled map in TMX format from file
-func LoadFromFile(fileName string, options ...loaderOption) (*Map, error) {
+func LoadFromFile(fileName string, options ...LoaderOption) (*Map, error) {
 	l := newLoader(options...)
 	return l.LoadFromFile(fileName)
 }
@@ -52,9 +52,10 @@ type Loader struct {
 	FileSystem fs.FS
 }
 
-type loaderOption func(*Loader)
+// LoaderOption is used with LoadFromReader and LoadFromFile functions to pass additional options
+type LoaderOption func(*Loader)
 
-func newLoader(options ...loaderOption) *Loader {
+func newLoader(options ...LoaderOption) *Loader {
 	l := &Loader{}
 	for _, opt := range options {
 		opt(l)
@@ -72,7 +73,7 @@ func (l *Loader) open(name string) (fs.File, error) {
 }
 
 // WithFileSystem returns an option to load level from a passed filesystem
-func WithFileSystem(fileSystem fs.FS) loaderOption {
+func WithFileSystem(fileSystem fs.FS) LoaderOption {
 	return func(l *Loader) {
 		l.FileSystem = fileSystem
 	}

--- a/tiled.go
+++ b/tiled.go
@@ -30,21 +30,21 @@ import (
 	"path/filepath"
 )
 
-// LoadFromReader function loads tiled map in TMX format from io.Reader
+// LoadReader function loads tiled map in TMX format from io.Reader
 // baseDir is used for loading additional tile data, current directory is used if empty
-func LoadFromReader(baseDir string, r io.Reader, options ...LoaderOption) (*Map, error) {
+func LoadReader(baseDir string, r io.Reader, options ...LoaderOption) (*Map, error) {
 	l := newLoader(options...)
-	return l.LoadFromReader(baseDir, r)
+	return l.LoadReader(baseDir, r)
 }
 
-// LoadFromFile function loads tiled map in TMX format from file
-func LoadFromFile(fileName string, options ...LoaderOption) (*Map, error) {
+// LoadFile function loads tiled map in TMX format from file
+func LoadFile(fileName string, options ...LoaderOption) (*Map, error) {
 	l := newLoader(options...)
-	return l.LoadFromFile(fileName)
+	return l.LoadFile(fileName)
 }
 
-// Loader provides configuration on how TMX maps and resources are loaded.
-type Loader struct {
+// loader provides configuration on how TMX maps and resources are loaded.
+type loader struct {
 	// A FileSystem that is used for loading TMX files and any external
 	// resources it may reference.
 	//
@@ -53,10 +53,10 @@ type Loader struct {
 }
 
 // LoaderOption is used with LoadFromReader and LoadFromFile functions to pass additional options
-type LoaderOption func(*Loader)
+type LoaderOption func(*loader)
 
-func newLoader(options ...LoaderOption) *Loader {
-	l := &Loader{}
+func newLoader(options ...LoaderOption) *loader {
+	l := &loader{}
 	for _, opt := range options {
 		opt(l)
 	}
@@ -65,7 +65,7 @@ func newLoader(options ...LoaderOption) *Loader {
 
 // open opens the given file using the Loader's FileSystem, or uses os.Open
 // if l or l.FileSystem is nil.
-func (l *Loader) open(name string) (fs.File, error) {
+func (l *loader) open(name string) (fs.File, error) {
 	if l == nil || l.FileSystem == nil {
 		return os.Open(name)
 	}
@@ -74,14 +74,14 @@ func (l *Loader) open(name string) (fs.File, error) {
 
 // WithFileSystem returns an option to load level from a passed filesystem
 func WithFileSystem(fileSystem fs.FS) LoaderOption {
-	return func(l *Loader) {
+	return func(l *loader) {
 		l.FileSystem = fileSystem
 	}
 }
 
-// LoadFromReader function loads tiled map in TMX format from io.Reader
+// LoadReader function loads tiled map in TMX format from io.Reader
 // baseDir is used for loading additional tile data, current directory is used if empty
-func (l *Loader) LoadFromReader(baseDir string, r io.Reader) (*Map, error) {
+func (l *loader) LoadReader(baseDir string, r io.Reader) (*Map, error) {
 	d := xml.NewDecoder(r)
 
 	m := &Map{
@@ -95,8 +95,8 @@ func (l *Loader) LoadFromReader(baseDir string, r io.Reader) (*Map, error) {
 	return m, nil
 }
 
-// LoadFromFile function loads tiled map in TMX format from file
-func (l *Loader) LoadFromFile(fileName string) (*Map, error) {
+// LoadFile function loads tiled map in TMX format from file
+func (l *loader) LoadFile(fileName string) (*Map, error) {
 	f, err := l.open(fileName)
 	if err != nil {
 		return nil, err
@@ -104,5 +104,5 @@ func (l *Loader) LoadFromFile(fileName string) (*Map, error) {
 	defer f.Close()
 
 	dir := filepath.Dir(fileName)
-	return l.LoadFromReader(dir, f)
+	return l.LoadReader(dir, f)
 }

--- a/tiled.go
+++ b/tiled.go
@@ -52,7 +52,7 @@ type loader struct {
 	FileSystem fs.FS
 }
 
-// LoaderOption is used with LoadFromReader and LoadFromFile functions to pass additional options
+// LoaderOption is used with LoadReader and LoadFile functions to pass additional options
 type LoaderOption func(*loader)
 
 func newLoader(options ...LoaderOption) *loader {

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -249,7 +249,7 @@ func TestEmbeddedLoader(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				return LoadReader("assets", file)
+				return LoadReader("assets", file, WithFileSystem(assetsFS))
 			},
 		},
 		{

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -238,9 +238,6 @@ func TestLoader(t *testing.T) {
 var assetsFS embed.FS
 
 func TestEmbeddedLoader(t *testing.T) {
-	loader := &Loader{
-		FileSystem: assetsFS,
-	}
 	tcs := []struct {
 		name string
 		load func() (*Map, error)
@@ -252,13 +249,13 @@ func TestEmbeddedLoader(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				return loader.LoadFromReader("assets", file)
+				return LoadFromReader("assets", file)
 			},
 		},
 		{
 			name: "LoadFromFile",
 			load: func() (*Map, error) {
-				return loader.LoadFromFile("assets/test2.tmx")
+				return LoadFromFile("assets/test2.tmx", WithFileSystem(assetsFS))
 			},
 		},
 	}
@@ -276,6 +273,13 @@ func TestEmbeddedLoader(t *testing.T) {
 			assert.Equal(t, tileset.Version, "1.2")
 			assert.Equal(t, tileset.TiledVersion, "1.2.3")
 		})
+	}
+}
+
+func TestLoadFromFileMissingFile(t *testing.T) {
+	_, err := LoadFromFile("missing-file.tmx")
+	if err == nil {
+		t.Fatal("expected LoadFromFile to return err, but no error was returned")
 	}
 }
 

--- a/tiled_test.go
+++ b/tiled_test.go
@@ -41,7 +41,7 @@ func GetAssetsDirectory() string {
 	return filepath.Join(filepath.Dir(filename), "assets")
 }
 
-func TestLoadFromReader(t *testing.T) {
+func TestLoadReader(t *testing.T) {
 	r := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8"?>
 <map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="4" height="4" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="2">
 <layer id="1" name="Tile Layer 1" width="4" height="4">
@@ -53,28 +53,28 @@ func TestLoadFromReader(t *testing.T) {
 </data>
 </layer>
 </map>`)
-	m, err := LoadFromReader(GetAssetsDirectory(), r)
+	m, err := LoadReader(GetAssetsDirectory(), r)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 	assert.Len(t, m.Layers, 1)
 }
 
-func TestLoadFromReaderError(t *testing.T) {
+func TestLoadReaderError(t *testing.T) {
 	r := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8"?>
 <map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="4" height="4" tilewidth="16" tileheight="16" infinite="0" nextlayerid="2" nextobjectid="2">
 <layer id="1" name="Tile Layer 1" width="4" height="4">
 <data encoding="csv">
 </layer>
 </map>`)
-	m, err := LoadFromReader(GetAssetsDirectory(), r)
+	m, err := LoadReader(GetAssetsDirectory(), r)
 
 	assert.Error(t, err)
 	assert.Nil(t, m)
 }
 
-func TestLoadFromFile(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "test.tmx"))
+func TestLoadFile(t *testing.T) {
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "test.tmx"))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -93,15 +93,15 @@ func TestLoadFromFile(t *testing.T) {
 	assert.Equal(t, true, m.ObjectGroups[0].Objects[0].Visible)
 }
 
-func TestLoadFromFileError(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "invalid.tmx"))
+func TestLoadFileError(t *testing.T) {
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "invalid.tmx"))
 
 	assert.Error(t, err)
 	assert.Nil(t, m)
 }
 
 func TestExternalTilesetImageLoaded(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "test2.tmx"))
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "test2.tmx"))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -123,7 +123,7 @@ func TestExternalTilesetImageLoaded(t *testing.T) {
 }
 
 func TestImageLayer(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "imagelayer.tmx"))
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "imagelayer.tmx"))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -145,7 +145,7 @@ func TestImageLayer(t *testing.T) {
 }
 
 func TestGroup(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "groups.tmx"))
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "groups.tmx"))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -178,7 +178,7 @@ func TestGroup(t *testing.T) {
 }
 
 func TestFont(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "font.tmx"))
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "font.tmx"))
 
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -219,12 +219,12 @@ func (t *testFileSystem) Open(filename string) (fs.File, error) {
 
 func TestLoader(t *testing.T) {
 	fs := &testFileSystem{}
-	loader := &Loader{
+	loader := &loader{
 		FileSystem: fs,
 	}
 
 	mapFile := filepath.Join(GetAssetsDirectory(), "loader.tmx")
-	m, err := loader.LoadFromFile(mapFile)
+	m, err := loader.LoadFile(mapFile)
 
 	if assert.Error(t, err) {
 		assert.True(t, os.IsNotExist(err), "expecting no exist error")
@@ -243,19 +243,19 @@ func TestEmbeddedLoader(t *testing.T) {
 		load func() (*Map, error)
 	}{
 		{
-			name: "LoadFromReader",
+			name: "LoadReader",
 			load: func() (*Map, error) {
 				file, err := assetsFS.Open("assets/test2.tmx")
 				if err != nil {
 					return nil, err
 				}
-				return LoadFromReader("assets", file)
+				return LoadReader("assets", file)
 			},
 		},
 		{
-			name: "LoadFromFile",
+			name: "LoadFile",
 			load: func() (*Map, error) {
-				return LoadFromFile("assets/test2.tmx", WithFileSystem(assetsFS))
+				return LoadFile("assets/test2.tmx", WithFileSystem(assetsFS))
 			},
 		},
 	}
@@ -276,10 +276,10 @@ func TestEmbeddedLoader(t *testing.T) {
 	}
 }
 
-func TestLoadFromFileMissingFile(t *testing.T) {
-	_, err := LoadFromFile("missing-file.tmx")
+func TestLoadFileMissingFile(t *testing.T) {
+	_, err := LoadFile("missing-file.tmx")
 	if err == nil {
-		t.Fatal("expected LoadFromFile to return err, but no error was returned")
+		t.Fatal("expected LoadFile to return err, but no error was returned")
 	}
 }
 
@@ -415,7 +415,7 @@ func TestFormatHexColor(t *testing.T) {
 }
 
 func TestVersions(t *testing.T) {
-	m, err := LoadFromFile(filepath.Join(GetAssetsDirectory(), "test2.tmx"))
+	m, err := LoadFile(filepath.Join(GetAssetsDirectory(), "test2.tmx"))
 
 	assert.Nil(t, err)
 

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -47,7 +47,7 @@ var (
 // layers are rendered by Tiled
 type Map struct {
 	// Loader for loading additional data
-	loader *Loader
+	loader *loader
 	// Base directory for loading additional data
 	baseDir string
 

--- a/tmx_object_test.go
+++ b/tmx_object_test.go
@@ -14,7 +14,7 @@ import (
 func TestLoadTilesetReferencedOnlyByObjectGroup(t *testing.T) {
 	const mapPath = "assets/test_tileobject.tmx"
 
-	m, err := tiled.LoadFromFile(mapPath)
+	m, err := tiled.LoadFile(mapPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit adds `tiled.WithFileSystem` which allows users to pass a `fs.FS` or `embed.FS` object like this:

```go
//go:embed data
var data embed.FS
...
m, err := tiled.LoadFromFile(path, tiled.WithFileSystem(data))
```

I used a bit simpler pattern for options which doesn't require defining interfaces and creating temporary option objects. If we need something more complex in the future, it'll be easy to add this complexity.

I'm not sure where I should document how to pass options into `tiled.Load*` functions, though. So if you have suggestions, I'd add some more doc comments where needed.
---
P.S. I'm not sure that `Loader` and `LoaderOption` should remain public - the API is good enough for users to not know about these internal types. What do you think? (this will be made in a next PR if you agree) 