### PR TITLE
Add "class" attribute to several elements.

### DIFF
--- a/tmx_group.go
+++ b/tmx_group.go
@@ -34,6 +34,8 @@ type Group struct {
 	ID uint32 `xml:"id,attr"`
 	// The name of the group layer.
 	Name string `xml:"name,attr"`
+	// The class of the group layer (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// Rendering offset of the image layer in pixels. Defaults to 0. (since 0.15)
 	OffsetX int `xml:"offsetx,attr"`
 	// Rendering offset of the image layer in pixels. Defaults to 0. (since 0.15)

--- a/tmx_image.go
+++ b/tmx_image.go
@@ -34,6 +34,8 @@ type ImageLayer struct {
 	ID uint32 `xml:"id,attr"`
 	// The name of the image layer.
 	Name string `xml:"name,attr"`
+	// The class of the image layer (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// Rendering offset of the image layer in pixels. Defaults to 0. (since 0.15)
 	OffsetX int `xml:"offsetx,attr"`
 	// Rendering offset of the image layer in pixels. Defaults to 0. (since 0.15)

--- a/tmx_layer.go
+++ b/tmx_layer.go
@@ -70,6 +70,8 @@ type Layer struct {
 	ID uint32 `xml:"id,attr"`
 	// The name of the layer.
 	Name string `xml:"name,attr"`
+	// The class of this layer (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// The opacity of the layer as a value from 0 to 1. Defaults to 1.
 	Opacity float32 `xml:"opacity,attr"`
 	// Whether the layer is shown (1) or hidden (0). Defaults to 1.

--- a/tmx_map.go
+++ b/tmx_map.go
@@ -55,6 +55,8 @@ type Map struct {
 	Version string `xml:"version,attr"`
 	// The Tiled version used to generate this file
 	TiledVersion string `xml:"tiledversion,attr"`
+	// The class of this map (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// Map orientation. Tiled supports "orthogonal", "isometric", "staggered" (since 0.9) and "hexagonal" (since 0.11).
 	Orientation string `xml:"orientation,attr"`
 	// The order in which tiles on tile layers are rendered. Valid values are right-down (the default), right-up, left-down and left-up.

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -43,6 +43,8 @@ type ObjectGroup struct {
 	ID uint32 `xml:"id,attr"`
 	// The name of the object group.
 	Name string `xml:"name,attr"`
+	// The class of the object group (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// The color used to display the objects in this group.
 	Color *HexColor `xml:"color,attr"`
 	// The opacity of the layer as a value from 0 to 1. Defaults to 1.
@@ -97,8 +99,10 @@ type Object struct {
 	ID uint32 `xml:"id,attr"`
 	// The name of the object. An arbitrary string.
 	Name string `xml:"name,attr"`
-	// The type of the object. An arbitrary string.
+	// The type of the object. An arbitrary string. (until 1.8)
 	Type string `xml:"type,attr"`
+	// The class of the object. An arbitrary string. (defaults to "", renamed from 'type' since 1.9)
+	Class string `xml:"class,attr"`
 	// The x coordinate of the object.
 	X float64 `xml:"x,attr"`
 	// The y coordinate of the object.

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -100,6 +100,8 @@ type Object struct {
 	// The name of the object. An arbitrary string.
 	Name string `xml:"name,attr"`
 	// The type of the object. An arbitrary string. (until 1.8)
+	//
+	// Deprecated: replaced by Class since 1.9
 	Type string `xml:"type,attr"`
 	// The class of the object. An arbitrary string. (defaults to "", renamed from 'type' since 1.9)
 	Class string `xml:"class,attr"`

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -25,6 +25,8 @@ type Tileset struct {
 	SourceLoaded bool `xml:"-"`
 	// The name of this tileset.
 	Name string `xml:"name,attr"`
+	// The class of this tileset (since 1.9, defaults to "").
+	Class string `xml:"class,attr"`
 	// The (maximum) width of the tiles in this tileset.
 	TileWidth int `xml:"tilewidth,attr"`
 	// The (maximum) height of the tiles in this tileset.
@@ -76,8 +78,10 @@ type Terrain struct {
 type TilesetTile struct {
 	// The local tile ID within its tileset.
 	ID uint32 `xml:"id,attr"`
-	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (since 1.0)
+	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (since 1.0, until 1.8)
 	Type string `xml:"type,attr"`
+	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (renamed from 'type' since 1.9)
+	Class string `xml:"class,attr"`
 	// Defines the terrain type of each corner of the tile, given as comma-separated indexes in the terrain types
 	// array in the order top-left, top-right, bottom-left, bottom-right.
 	// Leaving out a value means that corner has no terrain. (optional) (since 0.9)

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -79,6 +79,8 @@ type TilesetTile struct {
 	// The local tile ID within its tileset.
 	ID uint32 `xml:"id,attr"`
 	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (since 1.0, until 1.8)
+	//
+	// Deprecated: replaced by Class since 1.9
 	Type string `xml:"type,attr"`
 	// The type of the tile. Refers to an object type and is used by tile objects. (optional) (renamed from 'type' since 1.9)
 	Class string `xml:"class,attr"`


### PR DESCRIPTION
In the TMX version 1.9
(https://doc.mapeditor.org/en/stable/reference/tmx-changelog/#tiled-1-9),
the "type" attribute for <tile> and <object> was renamed to "class".

Also, the "class" field was added to several elements, namely, <map>,
<tileset>, <layer>, <imagelayer>, <objectgroup>, <group>, <wangset>
and <wangcolor>.

This patch adds the "class" attribute to all of the elements that are
specified in version 1.9 and that are implemented by the go-tiled
library.