### PR TITLE
Handle negative WangSet.TileID and WangColor.TileID.

### DIFF
--- a/assets/tilesets/test_wangset_tileset.tsx
+++ b/assets/tilesets/test_wangset_tileset.tsx
@@ -149,6 +149,9 @@
    <wangtile tileid="177" wangid="0,1,0,1,0,1,0,4"/>
    <wangtile tileid="178" wangid="0,1,0,4,0,1,0,4"/>
    <wangtile tileid="179" wangid="0,4,0,1,0,4,0,1"/>
-  </wangset>
- </wangsets>
+ </wangset>
+ <wangset name="New" type="corner" tile="-1">
+   <wangcolor name="Rock" color="#ff0000" tile="-1" probability="1"/>
+ </wangset>
+</wangsets>
 </tileset>

--- a/tmx_wangset.go
+++ b/tmx_wangset.go
@@ -22,7 +22,7 @@ type WangSet struct {
 	// Deprecated: replaced by Class since 1.9
 	Type string `xml:"type,attr"`
 	// The tile ID of the tile representing this Wang set.
-	TileID uint32 `xml:"tile,attr"`
+	TileID int64 `xml:"tile,attr"`
 	// The list of corner and/or edge colors.
 	WangColors []*WangColor `xml:"wangcolor"`
 	// The list of wang tiles.
@@ -38,7 +38,7 @@ type WangColor struct {
 	// The color in #RRGGBB format (example: #c17d11).
 	Color string `xml:"color,attr"`
 	// The tile ID of the tile representing this color.
-	TileID uint32 `xml:"tile,attr"`
+	TileID int64 `xml:"tile,attr"`
 	// The relative probability that this color is chosen over others in case of multiple options. (defaults to 0)
 	Probability float32 `xml:"probability,attr"`
 }


### PR DESCRIPTION
For full context please see the issue: https://github.com/lafriks/go-tiled/issues/65

This patch replaces 'uint32' with 'int64' as suggested in https://github.com/lafriks/go-tiled/issues/65#issuecomment-1214171708.