### PR TITLE
Add getter / setter for Tileset.baseDir

### DIFF
--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -55,7 +55,9 @@ type Tileset struct {
 }
 
 // BaseDir returns the base directory.
-func (ts *Tileset) BaseDir() string { return ts.baseDir }
+func (ts *Tileset) BaseDir() string {
+	return ts.baseDir
+}
 
 // SetBaseDir sets the base directory.
 func (ts *Tileset) SetBaseDir(baseDir string) { ts.baseDir = baseDir }

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -60,7 +60,9 @@ func (ts *Tileset) BaseDir() string {
 }
 
 // SetBaseDir sets the base directory.
-func (ts *Tileset) SetBaseDir(baseDir string) { ts.baseDir = baseDir }
+func (ts *Tileset) SetBaseDir(baseDir string) {
+	ts.baseDir = baseDir
+}
 
 // GetFileFullPath returns path to file relative to tileset file
 func (ts *Tileset) GetFileFullPath(fileName string) string {

--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -54,6 +54,12 @@ type Tileset struct {
 	WangSets WangSets `xml:"wangsets>wangset"`
 }
 
+// BaseDir returns the base directory.
+func (ts *Tileset) BaseDir() string { return ts.baseDir }
+
+// SetBaseDir sets the base directory.
+func (ts *Tileset) SetBaseDir(baseDir string) { ts.baseDir = baseDir }
+
 // GetFileFullPath returns path to file relative to tileset file
 func (ts *Tileset) GetFileFullPath(fileName string) string {
 	return filepath.Join(ts.baseDir, fileName)


### PR DESCRIPTION
Hi,

I wanted to ask if it would be possible to export the Tileset.BaseDir field?

Context: It's possible to load TSX files directly using the xml.NewDecoder() but it's not
possible to set the Tileset.baseDir field since this field is not exported.

This means that for TSX files loaded via the xml.NewDecoder(), it's not possible
to use the Tileset.GetFileFullPath() method to determine the location of
resources relative to the path of the tileset, e.g., the tileset image.

So far I have been employing a workaround which is to always pass the Tileset
and also the baseDir together as separate arguments, which is cumbersome. It
would be ideal if it were possible to set the Tileset.BaseDir field
directly. This means that if a TMX map is loaded by the go-tiled library, then
the go-tiled library sets the Tileset.BaseDir. However, if the TSX tileset is
loaded manually, then the code loading it manually can also set the field.

An alternative would be to extend the go-tiled library with functions to load
the Tileset from a file, from a reader, etc, but this would be additional
effort.

At the same time, the Tileset already contains a field (Tileset.SourceLoaded)
which is exported and annotated with `xml:"-"` so this approach of exported
fields that are not serialized is not new.

This patch exports the Tileset.BaseDir field. Other ideas are welcome!