### PR TITLE
Parallax and Properties.GetColor

### DIFF
--- a/tmx_group.go
+++ b/tmx_group.go
@@ -44,6 +44,10 @@ type Group struct {
 	Opacity float32 `xml:"opacity,attr"`
 	// Whether the layer is shown (1) or hidden (0). Defaults to 1.
 	Visible bool `xml:"visible,attr"`
+	// The parallax x factor of the layer 0 - 1.0
+	ParallaxX float32 `xml:"parallaxx,attr"`
+	// The parallax y factor of the layer 0 - 1.0
+	ParallaxY float32 `xml:"parallaxy,attr"`
 	// Custom properties
 	Properties Properties `xml:"properties>property"`
 	// Map layers

--- a/tmx_image.go
+++ b/tmx_image.go
@@ -52,6 +52,14 @@ type ImageLayer struct {
 	Properties Properties `xml:"properties>property"`
 	// The group image
 	Image *Image `xml:"image"`
+	// The parallax x factor of the layer 0 - 1.0
+	ParallaxX float32 `xml:"parallaxx,attr"`
+	// The parallax y factor of the layer 0 - 1.0
+	ParallaxY float32 `xml:"parallaxy,attr"`
+	// The repeat x settings of the image.
+	RepeatX bool `xml:"repeatx,attr"`
+	// The repeat y settings of the image.
+	RepeatY bool `xml:"repeaty,attr"`
 }
 
 // UnmarshalXML decodes a single XML element beginning with the given start element.

--- a/tmx_layer.go
+++ b/tmx_layer.go
@@ -80,6 +80,10 @@ type Layer struct {
 	OffsetX int `xml:"offsetx,attr"`
 	// Rendering offset for this layer in pixels. Defaults to 0. (since 0.14)
 	OffsetY int `xml:"offsety,attr"`
+	// The parallax x factor of the layer 0 - 1.0
+	ParallaxX float32 `xml:"parallaxx,attr"`
+	// The parallax y factor of the layer 0 - 1.0
+	ParallaxY float32 `xml:"parallaxy,attr"`
 	// Custom properties
 	Properties Properties `xml:"properties>property"`
 	// This is the attribute you'd like to use, not Data. Tile entry at (x,y) is obtained using l.DecodedTiles[y*map.Width+x].

--- a/tmx_object.go
+++ b/tmx_object.go
@@ -55,6 +55,10 @@ type ObjectGroup struct {
 	OffsetY int `xml:"offsety,attr"`
 	// Whether the objects are drawn according to the order of appearance ("index") or sorted by their y-coordinate ("topdown"). Defaults to "topdown".
 	DrawOrder string `xml:"draworder,attr"`
+	// The parallax x factor of the layer 0 - 1.0
+	ParallaxX float32 `xml:"parallaxx,attr"`
+	// The parallax y factor of the layer 0 - 1.0
+	ParallaxY float32 `xml:"parallaxy,attr"`
 	// Custom properties
 	Properties Properties `xml:"properties>property"`
 	// Group objects

--- a/tmx_property.go
+++ b/tmx_property.go
@@ -22,7 +22,11 @@ SOFTWARE.
 
 package tiled
 
-import "strconv"
+import (
+	"encoding/hex"
+	"image/color"
+	"strconv"
+)
 
 // Properties wraps any number of custom properties
 type Properties []*Property
@@ -102,4 +106,25 @@ func (p Properties) GetFloat(name string) float64 {
 		}
 	}
 	return 0
+}
+
+func (p Properties) GetColor(name string) color.Color {
+	for _, property := range p {
+		if property.Name != name || property.Type != "color" {
+			continue
+		}
+		str := property.Value
+		if len(str) < 6 {
+			continue
+		}
+		if str[0] == '#' {
+			str = str[1:]
+		}
+		b, err := hex.DecodeString(str)
+		if err != nil {
+			continue
+		}
+		return &color.RGBA{b[1], b[2], b[3], b[0]}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds parallax properties for layers as well as adds a helper method for custom properties to parse color information.