### PR TITLE
Fix Windows file paths with embbeded FS

### DIFF
--- a/render/renderer.go
+++ b/render/renderer.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/disintegration/imaging"
 	"github.com/lafriks/go-tiled"
@@ -86,10 +87,10 @@ func NewRendererWithFileSystem(m *tiled.Map, fs fs.FS) (*Renderer, error) {
 }
 
 func (r *Renderer) open(f string) (io.ReadCloser, error) {
-	if r.fs != nil {
-		return r.fs.Open(f)
+	if r.fs == nil {
+		return os.Open(filepath.FromSlash(f))
 	}
-	return os.Open(f)
+	return r.fs.Open(filepath.ToSlash(f))
 }
 
 func (r *Renderer) getTileImage(tile *tiled.LayerTile) (image.Image, error) {

--- a/tiled.go
+++ b/tiled.go
@@ -67,9 +67,9 @@ func newLoader(options ...LoaderOption) *loader {
 // if l or l.FileSystem is nil.
 func (l *loader) open(name string) (fs.File, error) {
 	if l == nil || l.FileSystem == nil {
-		return os.Open(name)
+		return os.Open(filepath.FromSlash(name))
 	}
-	return l.FileSystem.Open(name)
+	return l.FileSystem.Open(filepath.ToSlash(name))
 }
 
 // WithFileSystem returns an option to load level from a passed filesystem

--- a/tmx_wangset.go
+++ b/tmx_wangset.go
@@ -99,11 +99,11 @@ func (w *WangSet) GetWangColors(tileID uint32) (map[WangPosition]*WangColor, err
 	}
 
 	// convert from CSV to array of strings
-	wangIdsString := strings.Split(tile.WangID, ",")
+	wangIDsString := strings.Split(tile.WangID, ",")
 
 	// convert from array of strings to slice of uint32
-	var wangIds []uint32 // will contain a slice of the wangIds
-	for _, v := range wangIdsString {
+	var wangIDs []uint32 // will contain a slice of the wangIDs
+	for _, v := range wangIDsString {
 		id64, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			return nil, errors.New("internal error")
@@ -112,12 +112,12 @@ func (w *WangSet) GetWangColors(tileID uint32) (map[WangPosition]*WangColor, err
 		// uint64 to uint32
 		id := uint32(id64)
 
-		wangIds = append(wangIds, id)
+		wangIDs = append(wangIDs, id)
 	}
 
 	wangColors := make(map[WangPosition]*WangColor)
 
-	for i, id := range wangIds {
+	for i, id := range wangIDs {
 		if id == 0 { // no color assigned if id is 0, set to nil
 			wangColors[WangPosition(i)] = nil
 		} else {


### PR DESCRIPTION
Fixes https://github.com/lafriks/go-tiled/issues/63

File paths for `fs.FS` and `embed.FS` are considered valid if the have forward slashes "/", this is consistent with Linux and macOS, but not Windows. To fix this, now all paths are made valid with `filepath.ToSlash`, except when `os.Open` is called, where it uses the native OS separator with `filepath.FromSlash`. I hope this is enough to fix this issue for good.

Thanks for maintaining this great project :)