### PR TITLE
Fix tile transformations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Lint
       run: |

--- a/render/orthogonal.go
+++ b/render/orthogonal.go
@@ -47,14 +47,14 @@ func (e *OrthogonalRendererEngine) GetFinalImageSize() image.Rectangle {
 // RotateTileImage rotates provided tile layer.
 func (e *OrthogonalRendererEngine) RotateTileImage(tile *tiled.LayerTile, img image.Image) image.Image {
 	timg := img
+	if tile.DiagonalFlip {
+		timg = imaging.FlipH(imaging.Rotate270(timg))
+	}
 	if tile.HorizontalFlip {
 		timg = imaging.FlipH(timg)
 	}
 	if tile.VerticalFlip {
 		timg = imaging.FlipV(timg)
-	}
-	if tile.DiagonalFlip {
-		timg = imaging.FlipH(imaging.Rotate90(timg))
 	}
 
 	return timg


### PR DESCRIPTION
Tile transformations are not commutative, i.e. their order matters.
Although I did not find the order in tiled docs, trial and error method shows that Tiled uses next order of transformations:
1. Dflip
2. Hflip
3. Vflip