### PR TITLE
Return nil value without error when querying GetTilesetTile(0)

### DIFF
--- a/tmx_tileset.go
+++ b/tmx_tileset.go
@@ -151,6 +151,10 @@ func (ts *Tileset) GetTileRect(tileID uint32) image.Rectangle {
 
 // GetTilesetTile returns TilesetTile by tileID
 func (ts *Tileset) GetTilesetTile(tileID uint32) (*TilesetTile, error) {
+	if tileID == 0 {
+		return nil, nil
+	}
+
 	var tile *TilesetTile
 	for _, t := range ts.Tiles {
 		if t.ID == tileID {


### PR DESCRIPTION
Currently calling `Tileset.GetTilesetTile(0)` causes an error. I don't think this is desirable as the 0 value is regularly used for empty tiles. Instead, we can simply return the `nil, nil` values.